### PR TITLE
Flag to toggle expanding month

### DIFF
--- a/groupby.go
+++ b/groupby.go
@@ -14,9 +14,9 @@ import (
 
 const (
 	GROUPBY_VERSION    = "0.1.0"
-	SUBDIRECTORY_INNER = "├───"
+	SUBDIRECTORY_INNER = "├──"
 	SUBDIRECTORY_PIPE  = "│"
-	SUBDIRECTORY_LINK  = "└───"
+	SUBDIRECTORY_LINK  = "└──"
 )
 
 var (
@@ -119,19 +119,15 @@ func (p *PrintingVisitor) Visit(n *Node, depth int) {
 		}
 	}
 
+	prefix := SUBDIRECTORY_INNER
 	if !n.HasNext() {
-		if depth == 2 {
-			fmt.Println("└──", MonthAsName(n.FileName))
-		} else {
-			fmt.Println("└──", n.FileName)
-		}
-	} else {
-		if depth == 2 {
-			fmt.Println("├──", MonthAsName(n.FileName))
-		} else {
-			fmt.Println("├──", n.FileName)
-		}
+		prefix = SUBDIRECTORY_LINK
 	}
+
+	filename := FileNameByDepth(n.FileName, depth)
+
+	fmt.Println(prefix, filename)
+
 	p.previousLevel = depth
 }
 
@@ -154,6 +150,21 @@ func MonthAsName(monthStr string) string {
 	}
 
 	return time.Month(monthIdx).String()
+}
+
+// FileNameByDepth returns the filename, potentially modified depending on
+// the provided depth
+//
+// filename is a string containing the name of the file
+//
+// Depth is how deep down the file structure this file will be. The second
+// level is mapped to the month, so the name may be updated to its string representation.
+func FileNameByDepth(filename string, depth int) string {
+	if depth != 2 {
+		return filename
+	}
+
+	return MonthAsName(filename)
 }
 
 // Adapted from: https://stackoverflow.com/a/21067803
@@ -229,11 +240,7 @@ func (v *DirectoryVisitor) Visit(n *Node, depth int) {
 		return
 	}
 
-	if depth == 2 {
-		v.pathParts[depth-1] = MonthAsName(n.FileName)
-	} else {
-		v.pathParts[depth-1] = n.FileName
-	}
+	v.pathParts[depth-1] = FileNameByDepth(n.FileName, depth)
 
 	// We're probably at a month
 	if depth == 3 && !n.HasNext() {

--- a/groupby.go
+++ b/groupby.go
@@ -135,39 +135,25 @@ func (p *PrintingVisitor) Visit(n *Node, depth int) {
 	p.previousLevel = depth
 }
 
+// MonthAsName returns the full month name for the provided monthStr
+//
+// monthStr is a string usually containing the numeric representation of a
+// month (with January=1, February=2, etc.)
+//
+// If monthStr cannot be casted to an int, returns the provided parameter. If
+// monthStr is cast to an int that's not in the range [1, 12] inclusive,
+// returns an empty string
 func MonthAsName(monthStr string) string {
 	monthIdx, err := strconv.Atoi(monthStr)
 	if err != nil {
 		return monthStr
 	}
 
-	switch monthIdx {
-	case 1:
-		return "January"
-	case 2:
-		return "February"
-	case 3:
-		return "March"
-	case 4:
-		return "April"
-	case 5:
-		return "May"
-	case 6:
-		return "June"
-	case 7:
-		return "July"
-	case 8:
-		return "August"
-	case 9:
-		return "September"
-	case 10:
-		return "October"
-	case 11:
-		return "November"
-	case 12:
-		return "December"
+	if monthIdx < 1 || monthIdx > 12 {
+		return ""
 	}
-	return ""
+
+	return time.Month(monthIdx).String()
 }
 
 // Adapted from: https://stackoverflow.com/a/21067803

--- a/groupby.go
+++ b/groupby.go
@@ -31,6 +31,7 @@ var (
 	month             bool
 	day               bool
 	flatten           bool
+	expandMonth       bool
 	includeHidden     bool
 	dryRun            bool
 	excludePattern    string
@@ -52,6 +53,7 @@ func init() {
 	flag.BoolVar(&dryRun, "dry-run", false, "\tOnly show the output of how the files will be grouped")
 	flag.BoolVar(&dryRun, "preview", false, "\tOnly show the output of how the files will be grouped")
 	flag.BoolVar(&dryRun, "p", false, "\tOnly show the output of how the files will be grouped (shorthand)")
+	flag.BoolVar(&expandMonth, "expand-month", true, "\tUse the English name of the month (e.g. March) instead of the numeric value (default true)")
 	flag.BoolVar(&includeHidden, "a", false, "\tInclude hidden files and directories (starting with .)")
 	// flag.String(&exclude, "exclude", "Exclude files or directory matching a specified pattern")
 	// flag.BoolVar(&recurse, "R", "recurse" "Group files in subdirectories")
@@ -160,7 +162,7 @@ func MonthAsName(monthStr string) string {
 // Depth is how deep down the file structure this file will be. The second
 // level is mapped to the month, so the name may be updated to its string representation.
 func FileNameByDepth(filename string, depth int) string {
-	if depth != 2 {
+	if depth != 2 || expandMonth == false {
 		return filename
 	}
 

--- a/groupby_test.go
+++ b/groupby_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestMonthByName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"0", ""},
+		{"1", "January"},
+		{"2", "February"},
+		{"3", "March"},
+		{"4", "April"},
+		{"5", "May"},
+		{"6", "June"},
+		{"7", "July"},
+		{"8", "August"},
+		{"9", "September"},
+		{"10", "October"},
+		{"11", "November"},
+		{"12", "December"},
+		{"13", ""},
+		{"Non-Number", "Non-Number"},
+	}
+
+	for _, test := range tests {
+		result := MonthAsName(test.input)
+		if result != test.expected {
+			t.Errorf("MonthAsName(\"%s\") expects \"%s\", got \"%s\"", test.input, test.expected, result)
+		}
+	}
+}

--- a/groupby_test.go
+++ b/groupby_test.go
@@ -4,6 +4,25 @@ import (
 	"testing"
 )
 
+func TestFileNameByDepth(t *testing.T) {
+	tests := []struct {
+		filename string
+		depth    int
+		expected string
+	}{
+		{"03", 1, "03"},
+		{"03", 2, "March"},
+		{"Non-Number", 2, "Non-Number"},
+	}
+
+	for _, test := range tests {
+		result := FileNameByDepth(test.filename, test.depth)
+		if result != test.expected {
+			t.Errorf("FileNameByDepth(\"%s\", %d) expects \"%s\", got \"%s\"", test.filename, test.depth, test.expected, result)
+		}
+	}
+}
+
 func TestMonthByName(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -11,6 +30,7 @@ func TestMonthByName(t *testing.T) {
 	}{
 		{"0", ""},
 		{"1", "January"},
+		{"01", "January"},
 		{"2", "February"},
 		{"3", "March"},
 		{"4", "April"},

--- a/groupby_test.go
+++ b/groupby_test.go
@@ -6,19 +6,26 @@ import (
 
 func TestFileNameByDepth(t *testing.T) {
 	tests := []struct {
-		filename string
-		depth    int
-		expected string
+		filename    string
+		depth       int
+		expandMonth bool
+		expected    string
 	}{
-		{"03", 1, "03"},
-		{"03", 2, "March"},
-		{"Non-Number", 2, "Non-Number"},
+		{"1", 1, true, "1"},
+		{"1", 2, true, "January"},
+		{"03", 1, true, "03"},
+		{"03", 2, true, "March"},
+		{"03", 2, false, "03"},
+		{"Non-Number", 2, true, "Non-Number"},
 	}
 
 	for _, test := range tests {
+		// expandMonth is a global variable for script config
+		expandMonth = test.expandMonth
+
 		result := FileNameByDepth(test.filename, test.depth)
 		if result != test.expected {
-			t.Errorf("FileNameByDepth(\"%s\", %d) expects \"%s\", got \"%s\"", test.filename, test.depth, test.expected, result)
+			t.Errorf("FileNameByDepth(\"%s\", %d) with expectMonth: %t expects \"%s\", got \"%s\"", test.filename, test.depth, test.expandMonth, test.expected, result)
 		}
 	}
 }


### PR DESCRIPTION
This is actually my first PR on github, collaboration (maybe Go-llaboration? :-p). I'm open to suggestions on what I can do differently (I'm actually not sure what to write here).

I saw a couple places I thought could be cleaned up (e.g. turning an int to a month is included in time.Month), and I've implemented the suggestion from /u/nevym when he asked why the name of the month was being used.